### PR TITLE
Replace lwip

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulp-babel": "^6.1.2",
     "gulp-uglify": "^2.1.2",
     "jwt-simple": "^0.5.1",
-    "lwip": "0.0.9",
+    "pajk-lwip": "0.2.0",
     "mongoose": "^4.9.2",
     "mongoose-datatables": "^3.0.0",
     "morgan": "^1.8.1",

--- a/util/PaintingHandler.js
+++ b/util/PaintingHandler.js
@@ -1,4 +1,4 @@
-const lwip = require('lwip');
+const lwip = require('pajk-lwip');
 const Pixel = require('../models/pixel');
 
 const imageSize = 1000;


### PR DESCRIPTION
The lwip currently used has old libs and does not build on node v7 (latest version).

The version I'm replacing it with, `pajk-lwip`, (version `0.2.0`) does successfully build on my version of node.
