### PR TITLE
Small client- and server-side fixes, and admin forced password resets

### DIFF
--- a/client/js/place.js
+++ b/client/js/place.js
@@ -29,6 +29,11 @@ var canvasController = {
         this.isDisplayDirty = true;
     },
 
+    drawImageData: function(imageData) {
+        this.ctx.putImageData(imageData, 0, 0);
+        this.isDisplayDirty = true;
+    },
+
     setPixel: function(colour, x, y) {
         this.ctx.fillStyle = colour;
         this.ctx.fillRect(x, y, 1, 1);
@@ -153,7 +158,7 @@ var place = {
     placing: false, shouldShowPopover: false,
     panX: 0, panY: 0,
     DEFAULT_COLOURS: ["#FFFFFF", "#E4E4E4", "#888888", "#222222", "#FFA7D1", "#E50000", "#E59500", "#A06A42", "#E5D900", "#94E044", "#02BE01", "#00D3DD", "#0083C7", "#0000EA", "#CF6EE4", "#820080"],
-    selectedColour: null, handElement: null, unlockTime: null, secondTimer: null, lastUpdatedCoordinates: {x: null, y: null},
+    selectedColour: null, handElement: null, unlockTime: null, secondTimer: null, lastUpdatedCoordinates: {x: null, y: null}, loadedImage: false,
     notificationHandler: notificationHandler, hashHandler: hashHandler,
 
     start: function(canvas, zoomController, cameraController, displayCanvas, colourPaletteElement, coordinateElement, userCountElement, gridHint, pixelDataPopover, grid) {
@@ -214,12 +219,7 @@ var place = {
         $(this.coordinateElement).show();
         $(this.userCountElement).show();
 
-        this.loadImage().then(image => {
-            this.canvasController.clearCanvas();
-            this.canvasController.drawImage(image);
-            this.updateDisplayCanvas();
-            this.displayCtx.imageSmoothingEnabled = false;
-        });
+        this.getCanvasImage();
 
         this.changeUserCount(null);
         this.loadUserCount().then(online => {
@@ -229,6 +229,55 @@ var place = {
         this.socket = this.startSocketConnection();
 
         setInterval(function() { app.doKeys() }, 15);
+    },
+
+    getCanvasImage: function() {
+        var app = this;
+        this.adjustLoadingScreen("Loading…");;
+        this.loadImage().then(image => {
+            app.adjustLoadingScreen();
+            app.canvasController.clearCanvas();
+            app.canvasController.drawImage(image);
+            app.updateDisplayCanvas();
+            app.displayCtx.imageSmoothingEnabled = false;
+            app.loadedImage = true;
+        }).catch(err => {
+            console.error("Error loading board image", err);
+            if(typeof err.status !== "undefined" && err.status === 503) {
+                app.adjustLoadingScreen("Waiting for server…");
+                console.log("Server wants us to await its instruction");
+                setTimeout(function() {
+                    app.getCanvasImage()
+                }, 15000);
+            } else {
+                app.adjustLoadingScreen("An error occurred. Please wait…");
+                setTimeout(function() {
+                    app.getCanvasImage()
+                }, 5000);
+            }
+        });
+    },
+
+    loadImage: function() {
+        return new Promise((resolve, reject) => {
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', '/api/board-image', true);
+            xhr.responseType = 'blob';
+            xhr.onload = function(e) {
+                if(xhr.status == 200) {
+                    var url = URL.createObjectURL(this.response);
+                    var img = new Image();
+                    img.onload = function() {
+                        URL.revokeObjectURL(this.src);
+                        resolve(img);
+                    };
+                    img.onerror = () => reject(xhr);
+                    img.src = url;
+                } else reject(xhr);
+            };
+            xhr.onerror = () => reject(xhr);
+            xhr.send();
+        });
     },
 
     setupInteraction: function() {
@@ -302,6 +351,7 @@ var place = {
         socket.on("connect", () => console.log("Socket successfully connected"));
 
         socket.on("tile_placed", this.liveUpdateTile.bind(this));
+        socket.on("server_ready", () => this.getCanvasImage());
         socket.on("user_change", this.userCountChanged.bind(this));
         socket.on("reload_client", () => window.location.reload());
         return socket;
@@ -369,16 +419,6 @@ var place = {
 
     _getZoomMultiplier: function() {
         return this.zooming.zoomedIn ? 40 : 4;
-    },
-
-    loadImage: function() {
-        return new Promise((resolve, reject) => {
-            var image = new Image();
-            image.src = "/api/board-image";
-            image.onload = () => {
-                resolve(image);
-            };
-        });
     },
 
     animateZoom: function(callback = null) {
@@ -819,6 +859,14 @@ var place = {
             this.toggleZoom();
         } else if(keycode == 27 && this.selectedColour !== null) { // Esc - Deselect colour
             this.deselectColour();
+        }
+    },
+
+    adjustLoadingScreen: function(text = null) {
+        if(text) {
+            $("#loading").show().find(".text").text(text);
+        } else {
+            $("#loading").fadeOut();
         }
     }
 }

--- a/models/user.js
+++ b/models/user.js
@@ -28,6 +28,10 @@ var UserSchema = new Schema({
         type: Boolean,
         required: false
     },
+    passwordResetKey: {
+        type: String,
+        required: false
+    },
     usernameSet: {
         type: Boolean,
         required: true,

--- a/public/css/place.css
+++ b/public/css/place.css
@@ -404,3 +404,70 @@ body.signed-in #palette > #placing-modal.shown, body.signed-in #palette > #place
 .pixel-data > .user-info > .field {
     width: 100%;
 }
+
+#loading {
+    background-color: #fff;
+    position: absolute;
+    top: 50px;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    z-index: 5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+@-webkit-keyframes flair {
+  0% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+  }
+  50% {
+    -webkit-transform: scale(1.1);
+            transform: scale(1.1);
+  }
+  100% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+  }
+}
+@keyframes flair {
+  0% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+  }
+  50% {
+    -webkit-transform: scale(1.1);
+            transform: scale(1.1);
+  }
+  100% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+  }
+}
+
+
+#loading .icon {
+	-webkit-animation: flair 0.8s ease-in-out infinite both;
+	-moz-animation: flair 0.8s ease-in-out infinite both;
+	animation: flair 0.8s ease-in-out infinite both;
+}
+
+#loading .text {
+    font-size: 21px;
+    font-weight: 300;
+    display: block;
+    margin-top: 30px;
+}
+
+
+
+@supports (backdrop-filter:none) or (-webkit-backdrop-filter:none) {
+    #loading {
+        background: rgba(255,255,255,0.7);
+        -webkit-backdrop-filter: blur(12px);
+        backdrop-filter: blur(12px);
+    }
+}

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -10,6 +10,12 @@ function AdminRouter(app) {
     const responseFactory = require("../util/ResponseFactory")(app, "/admin");
 
     let router = express.Router()
+    
+    router.use(function(req, res, next) {
+        // Don't allow anything if user has forced pw reset or OAuth not configured
+        if(req.user && ((!req.user.usernameSet && req.user.OAuthName) || req.user.passwordResetKey)) res.redirect("/");
+        next(); // Otherwise, carry on...
+    });
 
     router.get('/', app.modMiddleware, function(req, res) {
         return responseFactory.sendRenderedResponse("admin/dashboard", req, res);

--- a/routes/api.js
+++ b/routes/api.js
@@ -40,6 +40,7 @@ function APIRouter(app) {
 
     router.post('/user/change_password', requireUser, function(req, res) {
         if (!req.body.old || !req.body.new) return res.status(403).json({success: false, error: {message: 'Your old password and a new password is required.', code: 'invalid_parameters'}});
+        if(req.user.isOauth) return res.status(400).json({success: false, error: {message: 'You may not change your password as you are using an external service for login.', code: 'regular_account_only'}});
         req.user.comparePassword(req.body.old, (error, match) => {
             if(!match || error) return res.status(401).json({success: false, error: {message: "The old password you entered was incorrect.", code: "incorrect_password"}});
             req.user.password = req.body.new;

--- a/routes/api.js
+++ b/routes/api.js
@@ -18,6 +18,11 @@ function APIRouter(app) {
         next();
     })
 
+    router.use(function(req, res, next) {
+        if(req.user && !req.user.usernameSet && req.user.OAuthName) return res.status(401).json({ success: false, error: { message: "Please create a username for your account before continuing.", code: "oauth_no_username" } })
+        next(); // Otherwise, carry on...
+    });
+
     const requireUser = (req, res, next) => {
         if (!req.user) return res.status(401).json({success: false, error: {message: "You are not signed in.", code: "not_signed_in"}});
         next()

--- a/routes/api.js
+++ b/routes/api.js
@@ -20,6 +20,7 @@ function APIRouter(app) {
 
     router.use(function(req, res, next) {
         if(req.user && !req.user.usernameSet && req.user.OAuthName) return res.status(401).json({ success: false, error: { message: "Please create a username for your account before continuing.", code: "oauth_no_username" } })
+        if(req.user && req.user.passwordResetKey) return res.status(401).json({ success: false, error: { message: "Please go to the Place 2.0 website to reset your password.", code: "forced_password_reset" }})
         next(); // Otherwise, carry on...
     });
 
@@ -44,7 +45,7 @@ function APIRouter(app) {
     });
 
     router.post('/user/change_password', requireUser, function(req, res) {
-        if (!req.body.old || !req.body.new) return res.status(403).json({success: false, error: {message: 'Your old password and a new password is required.', code: 'invalid_parameters'}});
+        if (!req.body.old || !req.body.new) return res.status(403).json({success: false, error: {message: 'Your old password and new password are required.', code: 'invalid_parameters'}});
         if(req.user.isOauth) return res.status(400).json({success: false, error: {message: 'You may not change your password as you are using an external service for login.', code: 'regular_account_only'}});
         req.user.comparePassword(req.body.old, (error, match) => {
             if(!match || error) return res.status(401).json({success: false, error: {message: "The old password you entered was incorrect.", code: "incorrect_password"}});

--- a/util/HTTPServer.js
+++ b/util/HTTPServer.js
@@ -95,8 +95,9 @@ function HTTPServer(app) {
     }
 
     // Production error handler, no stack traces shown to user
-    server.use(function(err, req, res, next) {
+    server.use((err, req, res, next) => {
         res.status(err.status || 500);
+        app.reportError(err);
         if (req.accepts('json') && !req.accepts("html")) return res.send({ success: false, error: { message: "An unknown error occured.", code: "internal_server_error" } });
         app.responseFactory.sendRenderedResponse("errors/500", req, res);
     });

--- a/util/HTTPServer.js
+++ b/util/HTTPServer.js
@@ -97,7 +97,7 @@ function HTTPServer(app) {
     // Production error handler, no stack traces shown to user
     server.use(function(err, req, res, next) {
         res.status(err.status || 500);
-        if (req.accepts('json') && !req.accepts("html")) return res.send({ error: 'An unknown error occured.' });
+        if (req.accepts('json') && !req.accepts("html")) return res.send({ success: false, error: { message: "An unknown error occured.", code: "internal_server_error" } });
         app.responseFactory.sendRenderedResponse("errors/500", req, res);
     });
 
@@ -105,7 +105,7 @@ function HTTPServer(app) {
     server.use((req, res, next) => {
         res.status(404);
         // respond with json
-        if (req.accepts('json') && !req.accepts("html")) return res.send({ error: 'Not found' });
+        if (req.accepts('json') && !req.accepts("html")) return res.send({ success: false, error: { message: "Page not found", code: "not_found" } });
         // send HTML
         app.responseFactory.sendRenderedResponse("errors/404", req, res);
     });

--- a/util/PaintingHandler.js
+++ b/util/PaintingHandler.js
@@ -52,6 +52,7 @@ function PaintingHandler(app) {
                             this.hasImage = true;
                             this.image = image;
                             this.imageBatch = this.image.batch();
+                            app.websocketServer.broadcast("server_ready", {});
                             resolve(image);
                         });
                     }).catch(err => reject(err));

--- a/util/passport.js
+++ b/util/passport.js
@@ -35,10 +35,14 @@ module.exports = function(passport) {
                 if(user.isOauth === true) return done(null, false, { error: { message: "Incorrect username or password provided.", code: "invalid_credentials" } });
                 if (user.loginError()) return done(null, false, { error: user.loginError() });
               
-                return user.comparePassword(password, function(err, match) {
-                    if (match && !err) return done(null, user);
-                    done(null, false, { error: { message: "Incorrect username or password provided.", code: "invalid_credentials" } });
-                });
+                if(user.passwordResetKey) {
+                    if(user.passwordResetKey == password) return done(null, user);
+                } else {
+                    return user.comparePassword(password, function(err, match) {
+                        if (match && !err) return done(null, user);
+                        done(null, false, { error: { message: "Incorrect username or password provided.", code: "invalid_credentials" } });
+                    });
+                }
             }
             done(null, false, { error: { message: "Incorrect username or password provided.", code: "invalid_credentials" } });
         });

--- a/views/public/account.html
+++ b/views/public/account.html
@@ -45,7 +45,7 @@ var isSelf = user ? user.id == profileUser.id : false;
   <% if(isSelf) { %>
   <hr>
   <h1>My account</h1>
-  <a class="btn btn-info" data-toggle="modal" data-target="#changePassword">Change Password</a>
+  <% if(profileUser.isOauth) { %><a class="btn btn-info" data-toggle="modal" data-target="#changePassword">Change Password</a><% } %>
   <a class="btn btn-danger" data-toggle="modal" data-target="#deactivateAccount">Deactivate Account</a>
   <% } %>
   <% if(user && user.canPerformActionsOnUser(profileUser)) { %>

--- a/views/public/force-pw-reset.html
+++ b/views/public/force-pw-reset.html
@@ -1,0 +1,20 @@
+<%- include('../header.html', {
+    pageTitle: "Reset your password",
+    css: ["/css/signin.css"]
+}) -%>
+<% if(typeof error === 'undefined') error = null; %>
+<div class="container">
+    <form class="form-signin" method="POST" action="/force-pw-reset">
+        <h2 class="form-signin-heading">Reset your password</h2>
+        <p>You are required to change your password to continue using Place 2.0.</p><br>
+        <label for="inputPassword" class="sr-only">Password</label>
+        <input type="password" id="inputPassword" class="form-control" placeholder="Password" name="password" required autofocus>
+        <label for="inputPasswordC" class="sr-only">Password (again)</label>
+        <input type="password" id="inputPasswordC" class="form-control" placeholder="Password (again)" name="confirmPassword" required>
+        <button class="btn btn-lg btn-primary btn-block" type="submit">Reset Password</button>
+        <% if(error) { %>
+            <br><div class="alert alert-danger"><strong>Uh oh!</strong> <%= error.message %></div>
+        <% } %>
+    </form>
+</div> <!-- /container -->
+<%- include('../footer.html') -%>

--- a/views/public/views/place.html
+++ b/views/public/views/place.html
@@ -1,4 +1,10 @@
 <div class="canvas-container">
+    <div id="loading">
+        <div class="content">
+            <img src="https://www.dynastic.co/img/dd-big.png" height="75" class="icon">
+            <span class="text">Loading…</span>
+        </div>
+    </div>
     <%- include("pixel_data.html") %>
     <div class="button-ctn">
         <div id="grid-button" class="control btn btn-success"></div>


### PR DESCRIPTION
- Allow forced password resets via database (until an admin UI is implemented for this)
- Allow canvas to be zoomed out with double click 
- New smart canvas loading screen
  - Allows user to see progress
  - Auto-retries on error
  - If server is waiting to load image, it will wait for server's "server_ready" command via sockets
- Disallow OAuth users to change their password
- Don't allow API requests from users without usernames set
- Fix JSON 404 and 500 error formats so that they match the API JSON error formats
- Properly report 500 errors to Cachet and log them on production
- Fix stack traces on development copies