### PR TITLE
User profile changes, popout chat, and admin logs

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ if (typeof app.config.bugSnagKey !== undefined) {
 
 // Get image handler
 app.paintingHandler = PaintingHandler(app);
-console.log("Loading image from the database...")
+console.log("Loading image from the database…")
 app.paintingHandler.loadImageFromDatabase().then((image) => {
     console.log("Successfully loaded image from database.");
 }).catch(err => {
@@ -94,7 +94,7 @@ function swallowError(error) {
 
 // Process JavaScript
 gulp.task('scripts', ['clean'], (cb) => {
-    console.log("Processing JavaScript...");
+    console.log("Processing JavaScript…");
     let t = gulp.src(paths.scripts.src)
     t = t.pipe(babel({ presets: ['es2015'] }));
     t = t.on("error", swallowError);

--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ if (typeof app.config.bugSnagKey !== undefined) {
 
 // Get image handler
 app.paintingHandler = PaintingHandler(app);
-console.log("Loading image from the database…")
+console.log("Loading image from the database…");
 app.paintingHandler.loadImageFromDatabase().then((image) => {
     console.log("Successfully loaded image from database.");
 }).catch(err => {

--- a/client/js/mod_tools.js
+++ b/client/js/mod_tools.js
@@ -220,7 +220,7 @@ function addToContainerForResponse(container, data, lastID, modOnly, limit, allo
             var btn = $(this);
             if(!loading) {
                 loading = true;
-                btn.html("<i class=\"fa fa-spin fa-circle-o-notch\"></i> Loading...").addClass("disabled");
+                btn.html("<i class=\"fa fa-spin fa-circle-o-notch\"></i> Loading…").addClass("disabled");
                 fetchActions(lastID, modOnly, limit, function(data, lastID) {
                     if(!data) {
                         loading = false;
@@ -235,7 +235,7 @@ function addToContainerForResponse(container, data, lastID, modOnly, limit, allo
 }
 
 function loadRecentActionsIntoContainer(container, limit = null, modOnly = false, allowsShowMore = true) {
-    container.html("<i class=\"fa fa-spin fa-circle-o-notch\"></i> Loading...");
+    container.html("<i class=\"fa fa-spin fa-circle-o-notch\"></i> Loading…");
     fetchActions(null, modOnly, limit, function(data, lastID) { 
         if(!data) return $(container).text("Couldn't load mod actions");
         container.html("");

--- a/client/js/mod_tools.js
+++ b/client/js/mod_tools.js
@@ -1,3 +1,5 @@
+var actionTemplates = null;
+
 var actions = {
     user: {
         ban: {
@@ -149,6 +151,7 @@ $("#broadcastForm").submit(function(e) {
 })
 
 function getRowForAction(action) {
+    var actionTemplate = actionTemplates[action.action];
     var randomString = function(length) {
         var text = "";
         var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -164,15 +167,15 @@ function getRowForAction(action) {
     var row = $("<div>").addClass("action").attr("data-action-id", action.id);
     console.log(action);
     var username = "<strong>Deleted user</strong>";
-    var actionTxt = `<span class="action-str" title="${action.action.displayName} - ${action.action.category}">${action.action.inlineDisplayName.toLowerCase()}`;
+    var actionTxt = `<span class="action-str" title="${actionTemplate.displayName} - ${actionTemplate.category}">${actionTemplate.inlineDisplayName.toLowerCase()}`;
     if(action.performingUser) username = `<strong><a href="/@${action.performingUser.username}">${action.performingUser.username}</a></strong>`;
     var moreInfoCtn = null;
     var sentenceEnd = "";
     var otherLines = "";
     if(Object.keys(action.info).length > 0) {
-        if(typeof action.action.sentenceEndTextFormatting !== 'undefined') sentenceEnd = parseActionTemplate(action.action.sentenceEndTextFormatting, action);
-        if(typeof action.action.otherLinesTextFormatting !== 'undefined') otherLines = "<br>" + parseActionTemplate(action.action.otherLinesTextFormatting, action);
-        if(typeof action.action.hideInfo === 'undefined' || !action.action.hideInfo) {
+        if(typeof actionTemplate.sentenceEndTextFormatting !== 'undefined') sentenceEnd = parseActionTemplate(actionTemplate.sentenceEndTextFormatting, action);
+        if(typeof actionTemplate.otherLinesTextFormatting !== 'undefined') otherLines = "<br>" + parseActionTemplate(actionTemplate.otherLinesTextFormatting, action);
+        if(typeof actionTemplate.hideInfo === 'undefined' || !actionTemplate.hideInfo) {
             var moreInfoCtn = $("<div>").addClass("info-collapse-ctn");
             var id = `info-collapse-${randomString(16)}-${action.id}`;
             var infoCtn = $("<div>").addClass("collapse info-collapse").attr("id", id).appendTo(moreInfoCtn);
@@ -190,7 +193,7 @@ function getRowForAction(action) {
         }
     }
     var text = `${username} ${actionTxt}${sentenceEnd}</span>.${otherLines}`;
-    if(typeof action.action.requiresModerator !== 'undefined' && action.action.requiresModerator) {
+    if(typeof actionTemplate.requiresModerator !== 'undefined' && actionTemplate.requiresModerator) {
         var modUsername = "<strong>Deleted moderator</strong>"
         if(action.moderatingUser) modUsername = `<strong><a href="/@${action.moderatingUser.username}">${action.moderatingUser.username}</a></strong>`;
         var text = `${modUsername} ${actionTxt} ${username}${sentenceEnd}</span>.${otherLines}`
@@ -203,7 +206,8 @@ function getRowForAction(action) {
 
 function fetchActions(lastID, modOnly, limit, callback) {
     $.get("/api/mod/actions", {lastID: lastID, limit: limit, modOnly: modOnly}).done(function(data) {
-        if(!data.success || !data.actions) return callback(null);
+        if(!data.success || !data.actions || !data.actionTemplates) return callback(null);
+        actionTemplates = data.actionTemplates;
         callback(data.actions);
     }).fail(function() {
         callback(null);

--- a/client/js/mod_tools.js
+++ b/client/js/mod_tools.js
@@ -79,6 +79,7 @@ var renderServerActions = function() {
     return `<div class="actions-ctn">
         ${renderAction("reloadConfig", {}, "server")}
         ${renderAction("refreshClients", {}, "server")}
+        <a href="javascript:void(0);" class="btn btn-info" data-toggle="modal" data-target="#broadcastModal">Broadcast message</button>
     </div>`
 }
 
@@ -129,3 +130,20 @@ $("body").on("click", ".server-action-btn", function() {
         if(action.callbackModifiesText === false) elem.html(originalText);
     });
 });
+
+
+$("#broadcastForm").submit(function(e) {
+    e.preventDefault();
+    $.post("/api/admin/broadcast", {
+        title: $(this).find("#inputBroadcastTitle").val(),
+        message: $(this).find("#inputBroadcastMessage").val(),
+        style: $(this).find("#inputBroadcastStyle").val(),
+        timeout: $(this).find("#inputBroadcastTimeout").val()
+    }).done(function(data) {
+        if(!data.success) return alert("Couldn't send broadcast");
+        $('#broadcastModal').modal('hide');
+        alert("Successfully sent out broadcast to all connected clients.");
+    }).fail(function() {
+        alert("Couldn't send broadcast");
+    })
+})

--- a/client/js/mod_tools.js
+++ b/client/js/mod_tools.js
@@ -207,6 +207,7 @@ function fetchActions(lastID, modOnly, limit, firstID, callback) {
         if(!data.success || !data.actions || !data.actionTemplates) return callback(null);
         actionTemplates = data.actionTemplates;
         callback(data.actions, data.lastID);
+        $(".timeago").timeago();
     }).fail(function() {
         callback(null, null);
     });

--- a/client/js/mod_tools.js
+++ b/client/js/mod_tools.js
@@ -178,13 +178,12 @@ function getRowForAction(action) {
             var moreInfoCtn = $("<div>").addClass("info-collapse-ctn");
             var id = `info-collapse-${randomString(16)}-${action.id}`;
             var infoCtn = $("<div>").addClass("collapse info-collapse").attr("id", id).appendTo(moreInfoCtn);
-            var infoList = $("<ol>").appendTo(infoCtn);
+            var infoList = $("<samp>").appendTo(infoCtn);
             Object.keys(action.info).forEach(key => {
                 var value = action.info[key];
                 if(typeof value !== 'object') {
-                    var thisRow = $("<li>").appendTo(infoList);
-                    $("<code>").text(key).appendTo(thisRow);
-                    $("<span>").text(`: ${value}`).appendTo(thisRow);
+                    $("<strong>").text(key + ":").appendTo(infoList);
+                    $("<span>").html(` ${value}<br>`).appendTo(infoList);
                 }
             })
             var seeMoreLink = $("<a>").attr("role", "button").addClass("see-more-toggle").attr("data-toggle", "collapse").attr("href", `#${id}`).attr("aria-expanded", "false").attr("aria-controls", id).text("See more").appendTo(moreInfoCtn);

--- a/client/js/place.js
+++ b/client/js/place.js
@@ -280,6 +280,9 @@ var place = {
 
         this.setupChat();
         this.loadLeaderboard();
+        setInterval(function() {
+            app.loadLeaderboard();
+        }, 30000);
         this.updateAuthLinks();
     },
 

--- a/client/js/place.js
+++ b/client/js/place.js
@@ -284,6 +284,9 @@ var place = {
             app.loadLeaderboard();
         }, 30000);
         this.updateAuthLinks();
+
+        this.dismissBtn = $("<button>").attr("type", "button").addClass("close").attr("data-dismiss", "alert").attr("aria-label", "Close");
+        $("<span>").attr("aria-hidden", "true").html("&times;").appendTo(this.dismissBtn);
     },
 
     getCanvasImage: function() {
@@ -431,6 +434,7 @@ var place = {
         socket.on("server_ready", () => this.getCanvasImage());
         socket.onJSON("new_message", this.addChatMessage.bind(this));
         socket.on("user_change", this.userCountChanged.bind(this));
+        socket.onJSON("admin_broadcast", this.adminBroadcastReceived.bind(this));
         socket.on("reload_client", () => window.location.reload());
         return socket;
     },
@@ -444,6 +448,10 @@ var place = {
 
     liveUpdateTile: function (data) {
         this.setPixel(`rgb(${data.colour.r}, ${data.colour.g}, ${data.colour.b})`, data.x, data.y);
+    },
+
+    adminBroadcastReceived: function(data) {
+        this.showAdminBroadcast(data.title, data.message, data.style || "info", data.timeout || 0);
     },
 
     userCountChanged: function (data) {
@@ -1153,6 +1161,23 @@ var place = {
             });
         }
         $("<p>").addClass("text-muted").text("Leaderboards are calculated based on the number of pixels you have placed (that someone else hasn't overwritten) over the span of the last week. To get a spot on the leaderboard, start placing!").appendTo(tab);
+    },
+
+    showAdminBroadcast(title, message, style, timeout = 0) {
+        var alert = $("<div>").addClass("floating-alert admin-alert alert alert-block alert-dismissable").addClass("alert-" + style).hide().prependTo($("#floating-alert-ctn"));
+        this.dismissBtn.clone().appendTo(alert);
+        var text = $("<p>").text(message).appendTo(alert);
+        if(title != null && title != "") {
+            $("<span>").text(" ").prependTo(text);
+            $("<strong>").text(title).prependTo(text);
+        }
+        alert.fadeIn(400, function() {
+            if(timeout > 0) {
+                setTimeout(function() {
+                    alert.fadeOut(400, function() { alert.remove(); });
+                }, timeout * 1000);
+            }
+        });
     }
 }
 

--- a/client/js/place.js
+++ b/client/js/place.js
@@ -905,6 +905,7 @@ var place = {
                     popover.find(".user-info, #pixel-badge, #pixel-user-state-badge").hide();
                     popover.find("#mod-user-action-ctn").html("");
                     popover.find("#pixel-data-username").removeAttr("href");
+                    popover.find(".rank-container").hide();
                 }
             });
         }

--- a/client/js/popout.js
+++ b/client/js/popout.js
@@ -1,0 +1,306 @@
+window.mobileAndTabletCheck = function() {
+  var check = false;
+  (function(a){if(/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(a)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0,4))) check = true;})(navigator.userAgent||navigator.vendor||window.opera);
+  return check;
+};
+
+function PopoutVisibilityController(popoutContainer) {
+    var controller = {
+        popoutContainer: popoutContainer,
+        tabChangeCallback: null, visibilityChangeCallback: null,
+
+        _setup: function() {
+            var p = this;
+            $(this.popoutContainer).find(".tabbar > .tab").click(function() {
+                p.changeTab($(this).data("tab-name"));
+            });
+            $(this.popoutContainer).find(".navigation-bar .close-btn").click(function() {
+                p.close();
+            });
+            if(window.mobileAndTabletCheck()) $(this.popoutContainer).find(".navigation-bar .popout-btn").hide();
+            $(this.popoutContainer).find(".navigation-bar .popout-btn").click(function() {
+                if($("body").hasClass("is-popped-out")) {
+                    window.close();
+                } else {
+                    var w = window.open("/popout", "Place_Popout", "directories=no,titlebar=no,toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=350,height=" + window.height);
+                    if (window.focus) {w.focus()}
+                    $("body").addClass("popped-out");
+                    if(p.visibilityChangeCallback) p.visibilityChangeCallback();
+                    w.onunload = function() {
+                        setTimeout(function() {
+                            if(w.closed) {
+                                $("body").removeClass("popped-out");
+                                if(p.visibilityChangeCallback) p.visibilityChangeCallback();
+                            }
+                        }, 1);
+                    }
+                }
+            });
+        },
+
+        changeTab: function(name) {
+            var p = this;
+            $(this.popoutContainer).find(".tab-content.active, .tab.active").removeClass("active");
+            $(this.popoutContainer).find(`.tab-content[data-tab-name=${name}], .tab[data-tab-name=${name}]`).addClass("active").each(function() {
+                if($(this).data("tab-title")) {
+                    p._adjustTitle($(this).data("tab-title"));
+                    return false;
+                }
+            });
+            if(this.tabChangeCallback) this.tabChangeCallback(name);
+        },
+
+        _adjustTitle: function(title) {
+            $(this.popoutContainer).find(".navigation-bar > .title").text(title);
+        },
+
+        open: function() {
+            $("body").addClass("popout-open");
+            if(this.visibilityChangeCallback) this.visibilityChangeCallback();
+        },
+        close: function() {
+            if($("body").hasClass("is-popped-out")) {
+                window.close();
+                if(window.opener.place) window.opener.place.popoutController.popoutVisibilityController.close();
+            } else {
+                $("body").removeClass("popout-open");
+                if(this.visibilityChangeCallback) this.visibilityChangeCallback();
+            }
+        },
+        toggle: function() {
+            $("body").toggleClass("popout-open");
+            if(this.visibilityChangeCallback) this.visibilityChangeCallback();
+        }
+    }
+    controller._setup();
+    return controller;
+}
+
+var popoutController = {
+    isOutdated: false, place: null,
+
+    setup: function(place, popoutContainer) {
+        this.popoutVisibilityController = PopoutVisibilityController(popoutContainer);
+        this.popoutVisibilityController.tabChangeCallback = name => {
+            if(name == "chat") this.scrollToChatBottom();
+        }
+        this.place = place;
+        var p = this;
+
+        this.setupChat();
+        this.loadLeaderboard();
+        setInterval(function() { p.loadLeaderboard() }, 30000);
+
+        this.startSocketConnection();
+    },
+
+    startSocketConnection: function() {
+        var socket = this.place.socket;
+
+        socket.onJSON = function(event, listener) {
+            return this.on(event, data => listener(JSON.parse(data)));
+        }
+
+        socket.on("error", e => {
+            console.log("Socket error: " + e)
+            this.isOutdated = true;
+        });
+        socket.on("connect", () => {
+            console.log("Socket successfully connected");
+            if(this.isOutdated) {
+                this.loadChatMessages();
+                this.isOutdated = false;
+            }
+        });
+
+        socket.onJSON("new_message", this.addChatMessage.bind(this));
+        return socket;
+    },
+
+    setupChat: function() {
+        var app = this;
+        this.loadChatMessages();
+        $("#chat-send-btn").click(function() {
+            app.sendChatMessage();
+        })
+        $("#chat-input-field").focus(function() {
+            app.scrollToChatBottom();
+        })
+        $("#chat-input-field").keydown(function(e) {
+            if((e.keyCode || e.which) != 13) return;
+            app.sendChatMessage();
+        })
+    },
+    
+    loadChatMessages: function() {
+        var app = this;
+        $.get("/api/chat").done(function(response) {
+            if(!response.success || !response.messages) console.log("Failed to load chat messages.");
+            app.messages = response.messages;
+            app.layoutMessages();
+        }).fail(function() {
+            console.log("Failed to load chat messages.");
+        });
+    },
+
+    layoutMessages: function() {
+        function getFancyDate(date) {
+            var now = new Date();
+            var almostSameDate = now.getMonth() == date.getMonth() && now.getFullYear() == date.getFullYear();
+            var isToday = now.getDate() == date.getDate();
+            var isYesterday = !isToday && now.getDate() == date.getDate() - 1;
+            return `${isToday ? "Today" : (isYesterday ? "Yesterday" : date.toLocaleDateString())}, ${date.toLocaleTimeString()}`
+        }
+
+        $("#chat-messages > *").remove();
+        var sinceLastTimestamp = 0;
+        const maxMessageBlock = 10;
+        this.messages.forEach((item, index, arr) => {
+            var outgoing = $("body").data("user-id") == item.userID;
+            // Check if this message is not the first
+            var hasLastMessage = index > 0;
+            // Get the date of the last message, if possible
+            var lastMessageDate = null;
+            if(hasLastMessage) lastMessageDate = new Date(arr[index - 1].date);
+            var messageDate = new Date(item.date);
+            // Check if this message has an attached user
+            var hasUser = !!item.user;
+            if(typeof item.userError === 'undefined') item.userError = null;
+            // Determine if this message should have a timestamp before it (they appear for first messages, every 10 messages without a timestamp, after 3 minute breaks, or if messages were sent on different days)
+            var needsTimestamp = sinceLastTimestamp > 10 || !hasLastMessage || (messageDate - lastMessageDate > 1000 * 60 * 3) || (messageDate.toDateString() !== lastMessageDate.toDateString());
+            // Determine if this message should show a username (checks if its not sent my user and if it is the first message sent, or if the message before it was sent by someone else)
+            var needsUsername = !outgoing && (needsTimestamp || !hasLastMessage || arr[index - 1].userID != item.userID);
+            // Determine if this message should show a coordinate (if its the last message, the previous message was sent by someone else, or separated by three minutes)
+            var needsCoordinate = index >= arr.length - 1 || (arr[index + 1].userID != item.userID || new Date(arr[index + 1].date) - messageDate > 1000 * 60 * 3 || sinceLastTimestamp == 10);
+            // Calculate our maximum message blocks
+            if(sinceLastTimestamp > 10) sinceLastTimestamp = 0;
+            if(!needsTimestamp) sinceLastTimestamp++;
+            if(needsTimestamp) $(`<div class="timestamp"></div>`).text(getFancyDate(new Date(item.date))).appendTo("#chat-messages");
+            var ctn = $(`<div class="message-ctn"><div class="clearfix"><div class="message"></div></div></div>`).addClass(outgoing ? "outgoing" : "incoming");
+            var usernameHTML = $(`<a class="username"><span></span></a>`);
+            usernameHTML.find("span").text(hasUser ? item.user.username : this.place.getUserStateText(item.userError))
+            if(hasUser) {
+                usernameHTML.attr("href", `/@${item.user.username}`);
+                if(item.user.banned || item.user.deactivated) $(`<span class="label label-danger badge-label"></span>`).text(item.user.banned ? "Banned" : "Deactivated").appendTo(usernameHTML);
+                if(item.user.moderator || item.user.admin) $(`<span class="label label-warning badge-label"></span>`).text(item.user.admin ? "Admin" : "Moderator").prependTo(usernameHTML);
+            } else usernameHTML.addClass("deleted-account");
+            if(needsUsername) usernameHTML.prependTo(ctn);
+            ctn.find(".message").text(item.text).attr("title", messageDate.toLocaleString());
+            if(needsCoordinate) {
+                var coords = $(`<a class="chat-coordinates" href="javascript:void(0);"><i class="fa fa-map-marker"></i> <span></span></a>`).click(() => {
+                    this.place.zoomIntoPoint(item.position.x, item.position.y, false);
+                    if($("body").hasClass("is-popped-out") && window.opener) window.opener.focus();
+                });
+                coords.find("span").text(`(${item.position.x.toLocaleString()}, ${item.position.y.toLocaleString()})`);
+                coords.appendTo(ctn);
+            }
+            ctn.appendTo("#chat-messages");
+        });
+        this.scrollToChatBottom();
+    },
+
+    addChatMessage: function(message) {
+        if(this.messages.map(m => m.id).indexOf(message.id) < 0) {
+            this.messages.push(message);
+            this.layoutMessages();
+        }
+    },
+
+    scrollToChatBottom: function() {
+        $("#chat-messages").scrollTop($("#chat-messages")[0].scrollHeight);
+    },
+
+    sendChatMessage: function() {
+        var parseError = function(response) {
+            var data = typeof response.error === "object" ? response : (typeof response.error().responseJSON === 'undefined' ? null : response.error().responseJSON);
+            return data.error.message ? data.error.message : "An error occurred while trying to send your chat message.";
+        }
+        var app = this;
+        var input = $("#chat-input-field");
+        var btn = $("#chat-send-btn");
+        if(input.val().length <= 0) return;
+        btn.text("Sending…").attr("disabled", "disabled");
+        console.log()
+        var coords = this.place.getCoordinates();
+        var text = input.val();
+        $.post("/api/chat", {
+            text: text,
+            x: coords.x,
+            y: coords.y
+        }).done(function(response) {
+            if(!response.success) return alert(parseError(response));
+            input.val("");
+            input.focus();
+            if(response.message) app.addChatMessage(response.message);
+        }).fail(function(response) {
+            alert(parseError(response));
+        }).always(function() {
+            btn.text("Send").removeAttr("disabled");
+        })
+    },
+
+    showTextOnLeaderboard: function(text) {
+        var tab = $("#leaderboardTab");
+        tab.html("");
+        $("<div>").addClass("coming-soon").text(text).appendTo(tab);
+    },
+
+    loadLeaderboard: function() {
+        var app = this;
+        $.get("/api/leaderboard").done(function(response) {
+            if(!response.success || !response.leaderboard) {
+                console.log("Failed to load leaderboard data.");
+                return app.showTextOnLeaderboard("Failed to load");
+            }
+            app.leaderboard = response.leaderboard;
+            app.layoutLeaderboard();
+        }).fail(function() {
+            console.log("Failed to load leaderboard data.");
+            app.showTextOnLeaderboard("Failed to load");
+        });
+    },
+
+    layoutLeaderboard: function() {
+        function getStatElement(name, value) {
+            var elem = $("<div>");
+            $("<span>").addClass("value").text(value).appendTo(elem);
+            $("<span>").addClass("name").text(name).appendTo(elem);
+            return elem;
+        }
+        var tab = $("#leaderboardTab");
+        tab.find("*").remove();
+        if(!this.leaderboard) return this.showTextOnLeaderboard("Loading…");
+        if(this.leaderboard.length <= 0) return this.showTextOnLeaderboard("No leaderboard data");
+        var topPlace = $(`<div class="top-place"><i class="fa fa-trophy big-icon"></i><span class="info">Leader</span></div>`).appendTo(tab);
+        var userInfo = $("<div>").addClass("leader-info").appendTo(topPlace);
+        $("<a>").addClass("name").attr("href", `/@${this.leaderboard[0].username}`).text(this.leaderboard[0].username).appendTo(userInfo);
+        $("<span>").addClass("pixel-label").text("Pixels placed").appendTo(userInfo);
+        var subdetails = $("<div>").addClass("subdetails row-fluid clearfix").appendTo(userInfo);
+        getStatElement("This week", this.leaderboard[0].statistics.placesThisWeek.toLocaleString()).addClass("col-xs-6").appendTo(subdetails);
+        getStatElement("Total", this.leaderboard[0].statistics.totalPlaces.toLocaleString()).addClass("col-xs-6").appendTo(subdetails);
+        if(this.leaderboard.length > 1) {
+            var table = $(`<table class="table"></table>`).appendTo(tab);
+            this.leaderboard.forEach((item, index) => {
+                if(index > 0) {
+                    var row = $("<tr>");
+                    $("<td>").addClass("bold").text(`${index + 1}.`).appendTo(row);
+                    $("<a>").text(item.username).attr("href", `/@${item.username}`).appendTo($("<td>").appendTo(row));
+                    var info1 = $("<td>").addClass("stat").appendTo(row);
+                    $("<span>").text(item.statistics.placesThisWeek.toLocaleString()).appendTo(info1);
+                    $("<span>").text("This week").addClass("row-label").appendTo(info1);
+                    var info2 = $("<td>").addClass("stat").appendTo(row);
+                    $("<span>").text(item.statistics.totalPlaces.toLocaleString()).appendTo(info2);
+                    $("<span>").text("Total").addClass("row-label").appendTo(info2);
+                    row.appendTo(table);
+                }
+            });
+        }
+        $("<p>").addClass("text-muted").text("Leaderboards are calculated based on the number of pixels you have placed (that someone else hasn't overwritten) over the span of the last week. To get a spot on the leaderboard, start placing!").appendTo(tab);
+    },
+}
+
+if($("body").hasClass("is-popped-out")) {
+    if(window.opener.place) {
+        popoutController.setup(window.opener.place, $("#popout-container")[0]);
+    }
+}

--- a/models/action.js
+++ b/models/action.js
@@ -20,7 +20,7 @@ ActionSchema.methods.toInfo = function() {
     var actionLogger = require("../util/ActionLogger");
     return {
         id: this.id,
-        action: actionLogger.infoForAction(this.actionID),
+        action: this.actionID,
         performingUserID: this.performingUserID,
         info: this.info || [],
         moderatingUserID: this.moderatingUserID,

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -235,6 +235,11 @@ table.filters {
 
 .action > p.text {
   margin-bottom: 5px;
+  font-size: 14px;
+}
+
+.action samp {
+  font-size: 13px;
 }
 
 .action > time {

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -210,3 +210,33 @@ table.filters {
 .content {
   margin-top: 10px;
 }
+
+.dashboard-actions-ctn {
+  padding: 10px 0;
+}
+
+.action {
+  border: 1px solid #eee;
+  margin-bottom: 10px;
+  border-radius: 10px;
+  padding: 20px;
+}
+
+.compact .action {
+  padding: 15px;
+  border-radius: 7px;
+}
+
+.compact .info-collapse-ctn {
+  display: none;
+}
+
+.action > p.text {
+  margin-bottom: 5px;
+}
+
+.action > time {
+  color: #777;
+  font-size: 12px;
+  margin-top: 0;
+}

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -240,6 +240,7 @@ table.filters {
 
 .action samp {
   font-size: 13px;
+  color: #555;
 }
 
 .action > time {

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -167,9 +167,9 @@ table.filters {
 
 /* User Display Block */
 .user {
-    border: 1px solid #ddd;
-    border-radius: 5px;
-    padding: 15px;
+    border: 1px solid #eee;
+    border-radius: 10px;
+    padding: 20px;
     margin: 5px 0;
 }
 .user.user-template {
@@ -177,7 +177,7 @@ table.filters {
 }
 .user .username {
     font-weight: 300;
-    font-size: 21px;
+    font-size: 19px;
     margin-bottom: 2px;
 }
 .user span {
@@ -190,7 +190,7 @@ table.filters {
 }
 .user .relation {
     color: #777;
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 600;
     text-transform: uppercase;
     margin-bottom: 3px;
@@ -198,6 +198,8 @@ table.filters {
 }
 .user .user-info {
     float: left;
+    font-size: 14px;
+    color: #555;
 }
 .user .user-actions {
     float: right;

--- a/public/css/global.css
+++ b/public/css/global.css
@@ -77,3 +77,20 @@ body:not([data-user-is-mod=true]) .actions-ctn, body:not([data-user-is-admin=tru
   letter-spacing: 0.8px;
   color: #888;
 }
+
+#floating-alert-ctn {
+  position: fixed;
+  top: 100px;
+  width: 100%;
+  padding: 0 20px;
+  z-index: 99;
+  pointer-events: none;
+}
+
+.floating-alert {
+  max-width: 600px;
+  width: 100%;
+  margin: 0 auto;
+  pointer-events: all;
+  margin-bottom: 5px;
+}

--- a/public/css/place.css
+++ b/public/css/place.css
@@ -511,7 +511,7 @@ body.signed-in #palette > #placing-modal.shown, body.signed-in #palette > #place
     display: none;
 }
 
-.popout-open #popout-container {
+.popout-open:not(.popped-out) #popout-container {
     display: flex;
 }
 
@@ -540,12 +540,17 @@ body.signed-in #palette > #placing-modal.shown, body.signed-in #palette > #place
     color: #333;
 }
 
-#popout-container > .navigation-bar .close-btn {
+#popout-container > .navigation-bar .buttons {
     color: #999;
-    font-size: 20px;
     text-align: right;
     margin-left: auto;
+}
+
+#popout-container > .navigation-bar .buttons > span {
     cursor: pointer;
+    font-size: 20px;
+    margin-left: 5px;
+    display: inline-block;
 }
 
 #popout-container > .tabbar {
@@ -804,7 +809,7 @@ body.signed-in #palette > #placing-modal.shown, body.signed-in #palette > #place
         background: #fff;
     }
 
-    .popout-open #popout-container {
+    .popout-open:not(.popped-out) #popout-container {
         top: 0;
     }
 }

--- a/public/css/popout.css
+++ b/public/css/popout.css
@@ -1,0 +1,19 @@
+#popout-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    display: flex;
+    margin: 0;
+    max-width: none;
+    padding: 0;
+}
+
+nav.navbar {
+    display: none;
+}
+
+.popout-btn {
+    transform: rotate(180deg);
+}

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -25,10 +25,6 @@ function AdminRouter(app) {
         return responseFactory.sendRenderedResponse("admin/coming_soon", req, res);
     });
 
-    router.get('/stats', app.modMiddleware, function(req, res) {
-        return responseFactory.sendRenderedResponse("admin/coming_soon", req, res);
-    });
-
     router.get('/log', app.modMiddleware, function(req, res) {
         return responseFactory.sendRenderedResponse("admin/coming_soon", req, res);
     });

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -22,11 +22,11 @@ function AdminRouter(app) {
     });
 
     router.get('/actions', app.modMiddleware, function(req, res) {
-        return responseFactory.sendRenderedResponse("admin/coming_soon", req, res);
+        return responseFactory.sendRenderedResponse("admin/actions", req, res, {title: "Recent Actions", modOnly: false});
     });
 
     router.get('/log', app.modMiddleware, function(req, res) {
-        return responseFactory.sendRenderedResponse("admin/coming_soon", req, res);
+        return responseFactory.sendRenderedResponse("admin/actions", req, res, {title: "Moderator Log", modOnly: true});
     });
 
     router.get('/users', app.modMiddleware, function(req, res) {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -29,11 +29,7 @@ function AdminRouter(app) {
         return responseFactory.sendRenderedResponse("admin/coming_soon", req, res);
     });
 
-    router.get('/log', app.adminMiddleware, function(req, res) {
-        return responseFactory.sendRenderedResponse("admin/coming_soon", req, res);
-    });
-
-    router.get('/pending', app.adminMiddleware, function(req, res) {
+    router.get('/log', app.modMiddleware, function(req, res) {
         return responseFactory.sendRenderedResponse("admin/coming_soon", req, res);
     });
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -235,6 +235,19 @@ function APIRouter(app) {
         res.json({success: true});
     });
 
+    router.post("/admin/broadcast", app.adminMiddleware, function(req, res, next) {
+        if(!req.body.title || !req.body.message || !req.body.timeout) return res.status(400).json({success: false});
+        var timeout = Number.parseInt(req.body.timeout);
+        if(Number.isNaN(timeout)) return res.status(400).json({success: false});
+        app.websocketServer.broadcast("admin_broadcast", {
+            title: req.body.title,
+            message: req.body.message,
+            timeout: Math.max(0, timeout),
+            style: req.body.style || "info"
+        });
+        res.json({success: true});
+    });
+
     router.post("/admin/users", app.modMiddleware, function(req, res, next) {
         let searchValue = req.body.search ? req.body.search.value || "" : "";
         var sort = { creationDate: "desc" };

--- a/routes/api.js
+++ b/routes/api.js
@@ -159,7 +159,7 @@ function APIRouter(app) {
                 app.reportError("Error fetching leaderboard: " + (err || "Returned null"))     
                 return res.status(500).json({ success: false });
             }
-            res.json({ success: true, leaderboard: leaderboard });
+            res.json({ success: true, leaderboard: leaderboard.splice(0, 25) });
         })
     });
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -366,9 +366,9 @@ function APIRouter(app) {
     });
 
     router.get('/mod/actions', app.modMiddleware, function(req, res) {
-        var condition = { actionID: { $in: ActionLogger.actionIDsToRetrieve(req.query.modOnly === true) } };
+        var condition = { actionID: { $in: ActionLogger.actionIDsToRetrieve(req.query.modOnly === "true") } };
         if (req.query.lastID) condition._id = { $gt: req.query.lastID };
-        Action.find(condition, {}, {_id: 1}).limit(Math.min(250, req.query.limit || 25)).then(actions => {
+        Action.find(condition, null, {sort: {_id: -1}}).limit(Math.min(250, req.query.limit || 25)).then(actions => {
             var lastID = null;
             if(actions.length > 1) lastID = actions[actions.length - 1]._id;
             var promises = actions.map(a => a.getInfo());
@@ -379,7 +379,6 @@ function APIRouter(app) {
             app.reportError("An error occurred while trying to retrieve actions: " + err);
             res.status(500).json({ success: false });
         })
-
     });
 
     // Debug APIs

--- a/routes/api.js
+++ b/routes/api.js
@@ -372,7 +372,7 @@ function APIRouter(app) {
             var lastID = null;
             if(actions.length > 1) lastID = actions[actions.length - 1]._id;
             var promises = actions.map(a => a.getInfo());
-            Promise.all(promises).then(actions => res.json({ success: true, actions: actions, lastID: lastID })).catch(err => res.status(500).json({ success: false }))
+            Promise.all(promises).then(actions => res.json({ success: true, actions: actions, lastID: lastID, actionTemplates: ActionLogger.getAllActionInfo() })).catch(err => res.status(500).json({ success: false }))
         }).catch(err => {
             app.reportError("An error occurred while trying to retrieve actions: " + err);
             res.status(500).json({ success: false });

--- a/routes/api.js
+++ b/routes/api.js
@@ -307,7 +307,7 @@ function APIRouter(app) {
             if(!req.user.canPerformActionsOnUser(user)) return res.status(403).json({success: false, error: {message: "You may not perform actions on this user.", code: "access_denied_perms"}});
             user.banned = !user.banned;
             user.save().then(user => {
-                // ActionLogger.log(user.banned ? "ban" : "unban", user, req.user);
+                ActionLogger.log(user.banned ? "ban" : "unban", user, req.user);
                 res.json({success: true, banned: user.banned})
             }).catch(err => {
                 app.reportError("Error trying to save banned status on user.");
@@ -370,6 +370,7 @@ function APIRouter(app) {
     router.get('/mod/actions', app.modMiddleware, function(req, res) {
         var condition = { actionID: { $in: ActionLogger.actionIDsToRetrieve(req.query.modOnly === "true") } };
         if (req.query.lastID) condition._id = { $lt: req.query.lastID };
+        else if (req.query.firstID) condition._id = { $gt: req.query.firstID };
         Action.find(condition, null, {sort: {_id: -1}}).limit(Math.min(250, req.query.limit || 25)).then(actions => {
             var lastID = null;
             if(actions.length > 1) lastID = actions[actions.length - 1]._id;

--- a/routes/api.js
+++ b/routes/api.js
@@ -305,7 +305,7 @@ function APIRouter(app) {
             if(!req.user.canPerformActionsOnUser(user)) return res.status(403).json({success: false, error: {message: "You may not perform actions on this user.", code: "access_denied_perms"}});
             user.banned = !user.banned;
             user.save().then(user => {
-                ActionLogger.log(user.banned ? "ban" : "unban", user, req.user);
+                // ActionLogger.log(user.banned ? "ban" : "unban", user, req.user);
                 res.json({success: true, banned: user.banned})
             }).catch(err => {
                 app.reportError("Error trying to save banned status on user.");
@@ -372,9 +372,7 @@ function APIRouter(app) {
             var lastID = null;
             if(actions.length > 1) lastID = actions[actions.length - 1]._id;
             var promises = actions.map(a => a.getInfo());
-            Promise.all(promises).then(actions => {
-                res.json({ success: true, actions: actions, lastID: lastID })
-            }).catch(err => res.status(500).json({ success: false }))
+            Promise.all(promises).then(actions => res.json({ success: true, actions: actions, lastID: lastID })).catch(err => res.status(500).json({ success: false }))
         }).catch(err => {
             app.reportError("An error occurred while trying to retrieve actions: " + err);
             res.status(500).json({ success: false });

--- a/routes/public.js
+++ b/routes/public.js
@@ -98,6 +98,10 @@ function PublicRouter(app) {
         return responseFactory.sendRenderedResponse("public/index", req, res);
     });
 
+    router.get('/popout', function(req, res) {
+        return responseFactory.sendRenderedResponse("public/popout", req, res);
+    });
+
     router.get('/guidelines', function(req, res, next) {
         fs.readFile(__dirname + "/../config/community_guidelines.md", "utf8", (err, data) => {
             if(err || !data) return next();

--- a/util/ActionLogger.js
+++ b/util/ActionLogger.js
@@ -101,7 +101,7 @@ var actionLogger = {
         Action({
             actionID: actionID,
             performingUserID: performingUser.id,
-            moderatingUser: moderatingUser ? moderatingUser.id : null,
+            moderatingUserID: moderatingUser ? moderatingUser.id : null,
             info: info,
             date: new Date()
         }).save().catch(err => app.reportError("An error occurred while trying to log action: " + err));

--- a/util/ActionLogger.js
+++ b/util/ActionLogger.js
@@ -31,7 +31,9 @@ var actions = {
     place: {
         displayName: "Place pixel",
         inlineDisplayName: "Placed a pixel",
-        category: "gameplay"
+        category: "gameplay",
+        hideInfo: true,
+        sentenceEndTextFormatting: " at <a href=\"/#x=${x}&y=${y}\">(${x}, ${y})</a>"
     },
     sendChatMessage: {
         displayName: "Send chat message",
@@ -109,6 +111,10 @@ var actionLogger = {
 
     infoForAction: function(actionID) {
         return actions[actionID];
+    },
+
+    getAllActionInfo: function() {
+        return actions;
     },
 
     actionIDsToRetrieve: function(modOnly = false) {

--- a/util/ActionLogger.js
+++ b/util/ActionLogger.js
@@ -96,6 +96,12 @@ var actions = {
         category: "administrative",
         isPrivileged: true
     },
+    sendBroadcast: {
+        displayName: "Broadcast a message to all users",
+        inlineDisplayName: "Broadcasted a message to all users",
+        category: "administrative",
+        isPrivileged: true
+    }
 }
 
 var actionLogger = {

--- a/util/LeaderboardManager.js
+++ b/util/LeaderboardManager.js
@@ -10,7 +10,7 @@ function LeaderboardManager(app) {
 
         update: function() {
             if(!this.needsUpdating) return;
-            console.log("Starting generation of leaderboard data...");
+            console.log("Starting generation of leaderboard data…");
             this.isUpdating = true;
             this.needsUpdating = false;
             var dateBackLastWeek = new Date(new Date().getTime() - (7 * 24 * 60 * 60 * 1000));

--- a/views/admin/actions.html
+++ b/views/admin/actions.html
@@ -1,0 +1,7 @@
+<%- include('../admin_header.html') -%>
+<h1 class="page-header"><%= title %></h1>
+<div id="actions-ctn"></div>
+<%- include('../admin_footer.html', {
+    js: ["/js/build/dashboard.js", "https://cdn.rawgit.com/rmm5t/jquery-timeago/180864a9c544a49e43719b457250af216d5e4c3a/jquery.timeago.js"],
+    jsSnippets: [`loadRecentActionsIntoContainer($("#actions-ctn"), null, ${modOnly})`]
+}) -%>

--- a/views/admin/dashboard.html
+++ b/views/admin/dashboard.html
@@ -167,7 +167,7 @@
     </tbody>
 </table>
 </div>-->
-<!-- Modal -->
+<% if(user.admin) { %>
 <div class="modal fade" id="broadcastModal" tabindex="-1" role="dialog" aria-labelledby="broadcastModalLabel">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -217,6 +217,7 @@
     </div>
   </div>
 </div>
+<% } %>
 <%- include('../admin_footer.html', {
     js: ["/js/build/admin_dashboard.js", "https://cdn.rawgit.com/rmm5t/jquery-timeago/180864a9c544a49e43719b457250af216d5e4c3a/jquery.timeago.js"],
     jsSnippets: jsSnippets

--- a/views/admin/dashboard.html
+++ b/views/admin/dashboard.html
@@ -29,7 +29,7 @@
 <div class="section-heading">
     <h2 class="sub-header">Administrator Actions</h2>
 </div>
-<div id="admin-actions" class="content">Loading...</div>
+<div id="admin-actions" class="content">Loading…</div>
 <% jsSnippets.push(`
     $("#admin-actions").html(renderServerActions())
 `) %>

--- a/views/admin/dashboard.html
+++ b/views/admin/dashboard.html
@@ -167,6 +167,56 @@
     </tbody>
 </table>
 </div>-->
+<!-- Modal -->
+<div class="modal fade" id="broadcastModal" tabindex="-1" role="dialog" aria-labelledby="broadcastModalLabel">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <form class="form-horizontal" id="broadcastForm">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title" id="broadcastModalLabel">Admin broadcast</h4>
+        </div>
+        <div class="modal-body">
+            <p>Send a message to all users currently viewing connected to the websockets.</p>
+            <div class="form-group">
+                <label for="inputBroadcastTitle" class="col-sm-2 control-label">Title</label>
+                <div class="col-sm-10">
+                    <input type="text" class="form-control" id="inputBroadcastTitle" placeholder="Title (optional)">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="inputBroadcastMessage" class="col-sm-2 control-label">Message</label>
+                <div class="col-sm-10">
+                    <input type="text" class="form-control" id="inputBroadcastMessage" placeholder="Message">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="inputBroadcastStyle" class="col-sm-2 control-label">Style</label>
+                <div class="col-sm-10">
+                    <select id="inputBroadcastStyle" class="selectpicker form-control">
+                        <option value="info">Informative</option>
+                        <option value="success">Success</option>
+                        <option value="warning">Warning</option>
+                        <option value="danger">Danger</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="inputBroadcastTimeout" class="col-sm-2 control-label">Timeout</label>
+                <div class="col-sm-10">
+                    <input type="number" class="form-control" id="inputBroadcastTimeout" placeholder="Timeout" value="0" aria-describedby="inputBroadcastTimeoutHelpBlock">
+                    <span id="inputBroadcastTimeoutHelpBlock" class="help-block">How long to wait before automatically dismissing the alert. Enter <strong>0</strong> to never automatically dismiss.</span>
+                </div>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-primary">Broadcast</button>
+        </div>
+        </form>
+    </div>
+  </div>
+</div>
 <%- include('../admin_footer.html', {
     js: ["/js/build/admin_dashboard.js", "https://cdn.rawgit.com/rmm5t/jquery-timeago/180864a9c544a49e43719b457250af216d5e4c3a/jquery.timeago.js"],
     jsSnippets: jsSnippets

--- a/views/admin/dashboard.html
+++ b/views/admin/dashboard.html
@@ -1,5 +1,5 @@
 <%- include('../admin_header.html') -%>
-<% var jsSnippets = []; %>
+<% var jsSnippets = [`loadRecentActionsIntoContainer($("#actions-ctn"), 10, false, false)`]; %>
 <h1 class="page-header">Dashboard</h1>
 <!-- Status Updates -->
 <div class="row placeholders">
@@ -36,137 +36,10 @@
 <% } %>
 <!-- Recent Actions -->
 <div class="section-heading">
-    <h2 class="sub-header">Recent actions</h2>
+    <h2 class="sub-header">Recent Actions</h2>
     <a href="/admin/actions">See all &raquo;</a>
 </div>
-<h4>eta son</h4>
-<!--<div class="table-responsive">
-<table class="table table-striped">
-    <thead>
-    <tr>
-        <th>#</th>
-        <th>Header</th>
-        <th>Header</th>
-        <th>Header</th>
-        <th>Header</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-        <td>1,001</td>
-        <td>Lorem</td>
-        <td>ipsum</td>
-        <td>dolor</td>
-        <td>sit</td>
-    </tr>
-    <tr>
-        <td>1,002</td>
-        <td>amet</td>
-        <td>consectetur</td>
-        <td>adipiscing</td>
-        <td>elit</td>
-    </tr>
-    <tr>
-        <td>1,003</td>
-        <td>Integer</td>
-        <td>nec</td>
-        <td>odio</td>
-        <td>Praesent</td>
-    </tr>
-    <tr>
-        <td>1,003</td>
-        <td>libero</td>
-        <td>Sed</td>
-        <td>cursus</td>
-        <td>ante</td>
-    </tr>
-    <tr>
-        <td>1,004</td>
-        <td>dapibus</td>
-        <td>diam</td>
-        <td>Sed</td>
-        <td>nisi</td>
-    </tr>
-    <tr>
-        <td>1,005</td>
-        <td>Nulla</td>
-        <td>quis</td>
-        <td>sem</td>
-        <td>at</td>
-    </tr>
-    <tr>
-        <td>1,006</td>
-        <td>nibh</td>
-        <td>elementum</td>
-        <td>imperdiet</td>
-        <td>Duis</td>
-    </tr>
-    <tr>
-        <td>1,007</td>
-        <td>sagittis</td>
-        <td>ipsum</td>
-        <td>Praesent</td>
-        <td>mauris</td>
-    </tr>
-    <tr>
-        <td>1,008</td>
-        <td>Fusce</td>
-        <td>nec</td>
-        <td>tellus</td>
-        <td>sed</td>
-    </tr>
-    <tr>
-        <td>1,009</td>
-        <td>augue</td>
-        <td>semper</td>
-        <td>porta</td>
-        <td>Mauris</td>
-    </tr>
-    <tr>
-        <td>1,010</td>
-        <td>massa</td>
-        <td>Vestibulum</td>
-        <td>lacinia</td>
-        <td>arcu</td>
-    </tr>
-    <tr>
-        <td>1,011</td>
-        <td>eget</td>
-        <td>nulla</td>
-        <td>Class</td>
-        <td>aptent</td>
-    </tr>
-    <tr>
-        <td>1,012</td>
-        <td>taciti</td>
-        <td>sociosqu</td>
-        <td>ad</td>
-        <td>litora</td>
-    </tr>
-    <tr>
-        <td>1,013</td>
-        <td>torquent</td>
-        <td>per</td>
-        <td>conubia</td>
-        <td>nostra</td>
-    </tr>
-    <tr>
-        <td>1,014</td>
-        <td>per</td>
-        <td>inceptos</td>
-        <td>himenaeos</td>
-        <td>Curabitur</td>
-    </tr>
-    <tr>
-        <td>1,015</td>
-        <td>sodales</td>
-        <td>ligula</td>
-        <td>in</td>
-        <td>libero</td>
-    </tr>
-    </tbody>
-</table>
-</div>-->
+<div id="actions-ctn" class="dashboard-actions-ctn compact"></div>
 <% if(user.admin) { %>
 <div class="modal fade" id="broadcastModal" tabindex="-1" role="dialog" aria-labelledby="broadcastModalLabel">
   <div class="modal-dialog" role="document">
@@ -174,7 +47,7 @@
       <form class="form-horizontal" id="broadcastForm">
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title" id="broadcastModalLabel">Admin broadcast</h4>
+            <h4 class="modal-title" id="broadcastModalLabel">Admin Broadcast</h4>
         </div>
         <div class="modal-body">
             <p>Send a message to all users currently viewing connected to the websockets.</p>
@@ -205,7 +78,7 @@
                 <label for="inputBroadcastTimeout" class="col-sm-2 control-label">Timeout</label>
                 <div class="col-sm-10">
                     <input type="number" class="form-control" id="inputBroadcastTimeout" placeholder="Timeout" value="0" aria-describedby="inputBroadcastTimeoutHelpBlock">
-                    <span id="inputBroadcastTimeoutHelpBlock" class="help-block">How long to wait before automatically dismissing the alert. Enter <strong>0</strong> to never automatically dismiss.</span>
+                    <span id="inputBroadcastTimeoutHelpBlock" class="help-block">How long to wait before automatically dismissing the alert in seconds. Enter <strong>0</strong> to never automatically dismiss.</span>
                 </div>
             </div>
         </div>

--- a/views/admin/similar_users.html
+++ b/views/admin/similar_users.html
@@ -7,7 +7,7 @@
     <a href="/admin/users">&laquo; Back to users</a>
 </div>
 <div id="data">
-    <div id="loading"><i class="fa fa-circle-o-notch fa-spin"></i> Loading similar accounts...</div>
+    <div id="loading"><i class="fa fa-circle-o-notch fa-spin"></i> Loading similar accounts…</div>
     <div id="target-ctn"></div><br>
     <div id="similar-ctn">
         <div class="heading"></div>

--- a/views/admin_header.html
+++ b/views/admin_header.html
@@ -20,8 +20,7 @@ var renderNavItem = function(name, itemPath) {
             <ul class="nav nav-sidebar">
                 <%- renderNavItem("Dashboard", "/admin/"); %>
                 <%- renderNavItem("Recent Actions", "/admin/actions"); %>
-                <% if(userAdmin) { %><%- renderNavItem("Moderator Log", "/admin/log"); %>
-                <%- renderNavItem("Pending Mod Actions", "/admin/pending"); %><% } %>
+                <%- renderNavItem("Moderator Log", "/admin/log"); %>
             </ul>
             <ul class="nav nav-sidebar">
                 <%- renderNavItem("Users", "/admin/users"); %>

--- a/views/footer.html
+++ b/views/footer.html
@@ -1,4 +1,5 @@
 <% if(typeof isAdmin === 'undefined') isAdmin = false;
+if(typeof needsLegit === 'undefined') needsLegit = false;
 if(typeof user === 'undefined') user = null;
 if(typeof js === 'undefined' || !js) js = [];
 if(typeof jsSnippets === 'undefined' || !jsSnippets) jsSnippets = [];
@@ -34,6 +35,6 @@ if(userMod) js.unshift("/js/build/mod_tools.js");
 </script>
 <% } 
 } %>
-<% if(fs.existsSync('./views/legit.html') && !isAdmin) { %><%- include("legit.html") -%><% } %>
+<% if(fs.existsSync('./views/legit.html') && !isAdmin && needsLegit) { %><%- include("legit.html") -%><% } %>
   </body>
 </html>

--- a/views/header.html
+++ b/views/header.html
@@ -5,6 +5,7 @@
   if(typeof isAdmin === 'undefined') isAdmin = false;
   if(typeof pinnable === 'undefined') pinnable = false;
   if(typeof navbarSupportsTopMode === 'undefined') navbarSupportsTopMode = false;
+  if(typeof isPoppedOut === 'undefined') isPoppedOut = false;
   var userAdmin = user ? user.admin : false, userMod = user ? user.moderator || userAdmin : false;
   var renderNavItem = function(name, itemPath, icon = null) {
       let isCurrentPage = itemPath == path || (isAdmin && itemPath == "/admin");
@@ -51,7 +52,7 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
   </head>
-  <body class="fixed-navbar<% if(user) { %> signed-in<% } %>" data-user-is-mod="<%= userMod %>" data-user-is-admin="<%= userAdmin %>" data-user-id="<%= user ? user._id : ""; %>">
+  <body class="fixed-navbar<% if(user) { %> signed-in<% } %><% if(isPoppedOut) { %> is-popped-out<% } %>" data-user-is-mod="<%= userMod %>" data-user-is-admin="<%= userAdmin %>" data-user-id="<%= user ? user._id : ""; %>">
     <nav class="navbar navbar-default navbar-fixed-top<% if(isAdmin) { %> navbar-inverse<% } %><%= navbarSupportsTopMode ? " supports-top" : "" %>" id="page-nav">
       <div class="container">
         <!-- Brand and toggle get grouped for better mobile display -->

--- a/views/public/index.html
+++ b/views/public/index.html
@@ -1,8 +1,9 @@
 <%- include('../header.html', {
     css: ["/css/compact.css", "/css/place.css"],
-    pinnable: true
+    pinnable: true,
+    needsLegit: true
 }) -%>
 <%- include("views/place.html") -%>
 <%- include('../footer.html', {
-    js: ["/socket.io/socket.io.js", "/js/interact.min.js", "/js/clipboard.min.js", "/js/build/place.js", "/js/jquery.timeago.js"]
+    js: ["/socket.io/socket.io.js", "/js/interact.min.js", "/js/clipboard.min.js", "/js/build/popout.js", "/js/build/place.js", "/js/jquery.timeago.js"]
 }) -%>

--- a/views/public/popout.html
+++ b/views/public/popout.html
@@ -1,0 +1,9 @@
+<%- include('../header.html', {
+    css: ["/css/compact.css", "/css/place.css", "/css/popout.css"],
+    pageTitle: "Popout",
+    isPoppedOut: true
+}) -%>
+<%- include("views/popout-container.html") -%>
+<%- include('../footer.html', {
+    js: ["/socket.io/socket.io.js", "/js/build/popout.js", "/js/jquery.timeago.js"]
+}) -%>

--- a/views/public/views/place.html
+++ b/views/public/views/place.html
@@ -1,3 +1,4 @@
+<div id="floating-alert-ctn"></div>
 <div id="place">
     <div id="loading">
         <div class="content">

--- a/views/public/views/place.html
+++ b/views/public/views/place.html
@@ -42,32 +42,5 @@
             </div>
         </div>
     </div>
-    <div id="popout-container">
-        <div class="navigation-bar">
-            <span class="title">Chat</span>
-            <span class="close-btn"><i class="fa fa-times"></i></span>
-        </div>
-        <div class="content-ctn">
-            <div class="tab-content active chat" data-tab-name="chat">
-                <div class="messages" id="chat-messages"></div>
-                <div class="text-field">
-                    <input type="text" maxlength="249" autocomplete="off" placeholder="Send a message" id="chat-input-field" />
-                    <a href="javascript:void(0)" class="send-btn" id="chat-send-btn">Send</a>
-                </div>
-            </div>
-            <div class="tab-content" data-tab-name="leaderboard" id="leaderboardTab">
-                <div class="coming-soon">
-                    <p>Loading…</p>
-                </div>
-            </div>
-        </div>
-        <div class="tabbar">
-            <div class="tab active" data-tab-name="chat" data-tab-title="Chat">
-                <i class="fa fa-comments"></i>
-            </div>
-            <div class="tab" data-tab-name="leaderboard" data-tab-title="Leaderboard">
-                <i class="fa fa-trophy"></i>
-            </div>
-        </div>
-    </div>
+    <%- include("popout-container.html") -%>
 </div>

--- a/views/public/views/popout-container.html
+++ b/views/public/views/popout-container.html
@@ -1,0 +1,31 @@
+<div id="popout-container">
+    <div class="navigation-bar">
+        <span class="title">Chat</span>
+        <div class="buttons">
+            <span class="popout-btn" aria-label="Popout"><i class="fa fa-external-link"></i></span>
+            <span class="close-btn" aria-label="Close"><i class="fa fa-times"></i></span>
+        </div>
+    </div>
+    <div class="content-ctn">
+        <div class="tab-content active chat" data-tab-name="chat">
+            <div class="messages" id="chat-messages"></div>
+            <div class="text-field">
+                <input type="text" maxlength="249" autocomplete="off" placeholder="Send a message" id="chat-input-field" />
+                <a href="javascript:void(0)" class="send-btn" id="chat-send-btn">Send</a>
+            </div>
+        </div>
+        <div class="tab-content" data-tab-name="leaderboard" id="leaderboardTab">
+            <div class="coming-soon">
+                <p>Loading…</p>
+            </div>
+        </div>
+    </div>
+    <div class="tabbar">
+        <div class="tab active" data-tab-name="chat" data-tab-title="Chat">
+            <i class="fa fa-comments"></i>
+        </div>
+        <div class="tab" data-tab-name="leaderboard" data-tab-title="Leaderboard">
+            <i class="fa fa-trophy"></i>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
- Changes the way users are ranked to work better
- Allows users to see current rank and weekly place count from pixel popover and profile pages
- Fix bug where moderator would not be recorded with log actions
- Add a UI for the action log
- Allow popping out the chat into a separate window
- Allow administrators to send out temporary broadcasts that appear on top of all connected clients' games non-modally
- Use 'pixels' everywhere we used to say 'tiles'
- Some other under the hood enhancements