### PR TITLE
Remove: unused 2 line in "moveCamera"

### DIFF
--- a/client/js/place.js
+++ b/client/js/place.js
@@ -775,9 +775,7 @@ var place = {
     },
 
     moveCamera: function(deltaX, deltaY, softAllowBoundPush = true) {
-        var cam = $(this.cameraController);
         var zoomModifier = this._getCurrentZoom();
-        var coords = this.getCoordinates();
         var x = deltaX / zoomModifier, y = deltaY / zoomModifier;
         this.setCanvasPosition(x, y, true, softAllowBoundPush);
     },


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1804755/48689558-17ea7380-ec06-11e8-9c79-5d45e976694f.png)

This is a very small PR
Only remove 2 line of code.
Because Visual Studio show these 2 line are not used.
it didn't effect any logic