### PR TITLE
Some modifications for anyone wanting to run this in 2025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,11 @@ WORKDIR /usr/src/app
 # Copy over package.json (and package-lock.json, if applicable)
 COPY package*.json yarn.lock ./
 
+COPY config/config.example.js config/config.js
+
 # Install app dependencies
-RUN yarn install
+RUN yarn install --ignore-engines
+# RUN npm rebuild uws
 
 # Bundle app source
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ COPY package*.json yarn.lock ./
 
 # Install app dependencies
 RUN yarn install --ignore-engines
-# RUN npm rebuild uws
 
 # Bundle app source
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ WORKDIR /usr/src/app
 # Copy over package.json (and package-lock.json, if applicable)
 COPY package*.json yarn.lock ./
 
-COPY config/config.example.js config/config.js
-
 # Install app dependencies
 RUN yarn install --ignore-engines
 # RUN npm rebuild uws

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       PORT: 3000
       ONLY_LISTEN_LOCAL: "false"
   db:
-    image: mongo
+    image: mongo:3.4
     restart: always
     volumes:
       - mongo-volume:/data/db

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "cookie-session": "^2.0.0-beta.1",
     "csurf": "^1.9.0",
     "del": "^2.2.2",
-    "dynastic-provider": "github:dynastic/accounts-provider",
+    "dynastic-provider": "git+https://github.com/dynastic/accounts-provider",
     "express": "^4.17.3",
     "express-brute-mongoose": "0.0.8",
     "express-recaptcha": "^2.1.0",

--- a/util/Markdown.js
+++ b/util/Markdown.js
@@ -1,4 +1,4 @@
-const marked = require("marked"),
+const {marked} = require("marked"),
     renderer = new marked.Renderer();
 
 renderer.code = function(code, lang) {


### PR DESCRIPTION
I know this repo hasn't been updated in a while, but I tried to run it with Docker and ran into a few problems. I found out that I needed to lock Mongo to a specific version, ignore Node version warnings and keep it at node:carbon (which is v8), and had to change some things to package.json since one of them is now a public Github archive.

I'm ignoring engine warnings when running `yarn install` because some packages need to be at Node version 12, but there are some errors regarding `uws` that can only be solved by being at node version 8. So I was caught in a cat-and-mouse situation. 

If anyone is simply trying to get this running in 2025, I hope this PR is helpful in some capacity.